### PR TITLE
Add config-based training and prediction

### DIFF
--- a/MASys.py
+++ b/MASys.py
@@ -49,3 +49,24 @@ class MultiAgentSystem:
         value = self.global_critic(obs_cat)
         # 可输出全局action概率等
         return value
+
+    def save(self, model_dir):
+        import os
+        os.makedirs(model_dir, exist_ok=True)
+        for i, actor in enumerate(self.actors):
+            torch.save(actor.state_dict(), os.path.join(model_dir, f"actor_{i}.pth"))
+        for i, critic in enumerate(self.critics):
+            torch.save(critic.state_dict(), os.path.join(model_dir, f"critic_{i}.pth"))
+        torch.save(self.global_critic.state_dict(), os.path.join(model_dir, "global_critic.pth"))
+
+    def load(self, model_dir):
+        import os
+        for i, actor in enumerate(self.actors):
+            path = os.path.join(model_dir, f"actor_{i}.pth")
+            actor.load_state_dict(torch.load(path, map_location=self.device))
+        for i, critic in enumerate(self.critics):
+            path = os.path.join(model_dir, f"critic_{i}.pth")
+            critic.load_state_dict(torch.load(path, map_location=self.device))
+        gc_path = os.path.join(model_dir, "global_critic.pth")
+        self.global_critic.load_state_dict(torch.load(gc_path, map_location=self.device))
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # CMDAR
-This is a implemention for CMDAR algorithm.  
+This is a implemention for CMDAR algorithm.
 Paper: [Dynamic Routing for Integrated Satellite-Terrestrial Networks: A Constrained Multi-Agent Reinforcement Learning Approach](https://ieeexplore.ieee.org/abstract/document/10436098/authors#authors)
+
+## Usage
+
+1. Adjust the hyperparameters in `config.json`. The file contains all settings for training and inference, including the path to the dataset and the directory used to store trained models.
+2. Run training
+   ```bash
+   python train.py
+   ```
+   Trained weights will be saved under the directory specified by `model_dir` in the config file.
+3. Run prediction
+   ```bash
+   python predict.py
+   ```
+   The script loads the saved model and reports loss rate, energy consumption and average delay.

--- a/config.json
+++ b/config.json
@@ -1,0 +1,9 @@
+{
+  "dataset_path": "data/prediction_data.json",
+  "model_dir": "model",
+  "num_episodes": 100,
+  "gamma": 0.98,
+  "cost_limits": {"energy": 0.5, "loss": 5},
+  "hidden_dim": 64,
+  "device": "cpu"
+}

--- a/model/.gitignore
+++ b/model/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/train.py
+++ b/train.py
@@ -1,0 +1,51 @@
+import json
+from ISTN_ENV import ISTNEnv
+from MASys import MultiAgentSystem
+from LM import train_cmadr
+
+
+def load_config(path: str) -> dict:
+    with open(path, 'r') as f:
+        return json.load(f)
+
+
+def build_env(data: dict) -> ISTNEnv:
+    return ISTNEnv(
+        num_satellites=len(data['sat_positions_per_slot'][0]),
+        num_ground_stations=len(data['gs_positions']),
+        max_time=len(data['sat_positions_per_slot']),
+        sat_positions_per_slot=data['sat_positions_per_slot'],
+        gs_positions=[tuple(p) for p in data['gs_positions']],
+        queries=data['queries'],
+    )
+
+
+def main(config_path: str = 'config.json') -> None:
+    cfg = load_config(config_path)
+    with open(cfg['dataset_path'], 'r') as f:
+        data = json.load(f)
+
+    env = build_env(data)
+    mac = MultiAgentSystem(
+        n_agents=env.num_satellites + env.num_ground_stations,
+        n_nodes=env.num_satellites + env.num_ground_stations,
+        obs_dim=env.obs_dim,
+        action_dim=env.action_dim,
+        hidden_dim=cfg.get('hidden_dim', 64),
+        device=cfg.get('device', 'cpu'),
+    )
+
+    train_cmadr(
+        env,
+        mac,
+        num_episodes=cfg.get('num_episodes', 100),
+        gamma=cfg.get('gamma', 0.98),
+        cost_limits=cfg.get('cost_limits', {'energy': 0.5, 'loss': 5}),
+        device=cfg.get('device', 'cpu'),
+    )
+
+    mac.save(cfg.get('model_dir', 'model'))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `config.json` for hyperparameters
- implement save/load methods in `MultiAgentSystem`
- create `train.py` for training only
- rewrite `predict.py` to load trained model
- document workflow in README

## Testing
- `python -m py_compile AC.py ISTN_ENV.py LM.py MASys.py data_generator.py main.py predict.py train.py`

------
https://chatgpt.com/codex/tasks/task_e_684da1060fc48330987df494df7d44ae