### PR TITLE
Add config based train and prediction scripts

### DIFF
--- a/MASys.py
+++ b/MASys.py
@@ -49,3 +49,28 @@ class MultiAgentSystem:
         value = self.global_critic(obs_cat)
         # 可输出全局action概率等
         return value
+
+    def save(self, model_dir: str):
+        """Save model parameters to ``model_dir``."""
+        import os
+        os.makedirs(model_dir, exist_ok=True)
+        for idx, actor in enumerate(self.actors):
+            torch.save(actor.state_dict(), os.path.join(model_dir, f"actor_{idx}.pt"))
+        for idx, critic in enumerate(self.critics):
+            torch.save(critic.state_dict(), os.path.join(model_dir, f"critic_{idx}.pt"))
+        torch.save(self.global_critic.state_dict(), os.path.join(model_dir, "global_critic.pt"))
+
+    def load(self, model_dir: str):
+        """Load model parameters from ``model_dir``."""
+        import os
+        for idx, actor in enumerate(self.actors):
+            path = os.path.join(model_dir, f"actor_{idx}.pt")
+            if os.path.exists(path):
+                actor.load_state_dict(torch.load(path, map_location=self.device))
+        for idx, critic in enumerate(self.critics):
+            path = os.path.join(model_dir, f"critic_{idx}.pt")
+            if os.path.exists(path):
+                critic.load_state_dict(torch.load(path, map_location=self.device))
+        path = os.path.join(model_dir, "global_critic.pt")
+        if os.path.exists(path):
+            self.global_critic.load_state_dict(torch.load(path, map_location=self.device))

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # CMDAR
-This is a implemention for CMDAR algorithm.  
+This is a implemention for CMDAR algorithm.
 Paper: [Dynamic Routing for Integrated Satellite-Terrestrial Networks: A Constrained Multi-Agent Reinforcement Learning Approach](https://ieeexplore.ieee.org/abstract/document/10436098/authors#authors)
+
+## Usage
+
+1. **Train**
+
+   ```bash
+   python train.py --config config.json
+   ```
+
+   The trained weights will be stored in the directory specified by `model_dir` in `config.json`.
+
+2. **Predict**
+
+   ```bash
+   python predict.py --config config.json
+   ```
+
+   The script loads the saved model and evaluates it on the dataset.

--- a/config.json
+++ b/config.json
@@ -1,0 +1,10 @@
+{
+  "data_path": "data/prediction_data.json",
+  "model_dir": "model",
+  "device": "cpu",
+  "train": {
+    "num_episodes": 10,
+    "gamma": 0.98,
+    "cost_limits": {"energy": 0.5, "loss": 5}
+  }
+}

--- a/train.py
+++ b/train.py
@@ -1,0 +1,57 @@
+import json
+import argparse
+from ISTN_ENV import ISTNEnv
+from MASys import MultiAgentSystem
+from LM import train_cmadr
+
+
+def load_config(path: str) -> dict:
+    with open(path, 'r') as f:
+        return json.load(f)
+
+
+def build_env_from_data(data: dict) -> ISTNEnv:
+    return ISTNEnv(
+        num_satellites=len(data['sat_positions_per_slot'][0]),
+        num_ground_stations=len(data['gs_positions']),
+        max_time=len(data['sat_positions_per_slot']),
+        sat_positions_per_slot=data['sat_positions_per_slot'],
+        gs_positions=[tuple(p) for p in data['gs_positions']],
+        queries=data['queries'],
+    )
+
+
+def main(config_path: str):
+    cfg = load_config(config_path)
+    with open(cfg['data_path'], 'r') as f:
+        data = json.load(f)
+
+    env = build_env_from_data(data)
+    mac = MultiAgentSystem(
+        n_agents=env.num_satellites + env.num_ground_stations,
+        n_nodes=env.num_satellites + env.num_ground_stations,
+        obs_dim=env.obs_dim,
+        action_dim=env.action_dim,
+        hidden_dim=64,
+        device=cfg.get('device', 'cpu'),
+    )
+
+    train_cfg = cfg.get('train', {})
+    train_cmadr(
+        env,
+        mac,
+        num_episodes=train_cfg.get('num_episodes', 10),
+        gamma=train_cfg.get('gamma', 0.98),
+        cost_limits=train_cfg.get('cost_limits', {'energy': 0.5, 'loss': 5}),
+        device=cfg.get('device', 'cpu'),
+    )
+
+    mac.save(cfg['model_dir'])
+    print(f"Model saved to {cfg['model_dir']}")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--config', default='config.json', help='Path to config file')
+    args = parser.parse_args()
+    main(args.config)


### PR DESCRIPTION
## Summary
- decouple train/predict with `train.py` and `predict.py`
- add a JSON config file for data path, model path, and training parameters
- allow `MultiAgentSystem` to save/load models
- update README with instructions

## Testing
- `python train.py --config config.json`
- `python predict.py --config config.json`
- `python -m py_compile AC.py ISTN_ENV.py MASys.py LM.py data_generator.py predict.py train.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_684da76610d083309c4ce41d7a6a2e63