### PR TITLE
Support timed queries and new configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ Paper: [Dynamic Routing for Integrated Satellite-Terrestrial Networks: A Constra
    python train.py --config config.json
    ```
 
-   The trained weights will be stored in the directory specified by `model_dir` in `config.json`.
+   The dataset name is given by `data_name` and the model will be saved to
+   `model/<round>_<data_name>`. Training parameters such as the number of
+   satellites, ground stations, queries and the maximum time slot are configured
+   in `config.json`.
 
 2. **Predict**
 

--- a/config.json
+++ b/config.json
@@ -1,10 +1,19 @@
 {
-  "data_path": "data/prediction_data.json",
-  "model_dir": "model",
+  "data_dir": "data",
+  "data_name": "prediction_data",
+  "model_root": "model",
+  "round": 1,
   "device": "cpu",
   "train": {
     "num_episodes": 10,
     "gamma": 0.98,
-    "cost_limits": {"energy": 0.5, "loss": 5}
+    "cost_limits": {"energy": 0.5, "loss": 5},
+    "num_satellites": 5,
+    "num_ground_stations": 5,
+    "num_queries": 10,
+    "max_time": 50
+  },
+  "predict": {
+    "max_time": 50
   }
 }

--- a/data/prediction_data.json
+++ b/data/prediction_data.json
@@ -1125,44 +1125,54 @@
   ],
   "queries": [
     {
-      "src": 0,
-      "dst": 2
-    },
-    {
       "src": 2,
-      "dst": 0
+      "dst": 1,
+      "time": 1
     },
     {
       "src": 4,
-      "dst": 1
+      "dst": 0,
+      "time": 6
     },
     {
       "src": 1,
-      "dst": 3
+      "dst": 3,
+      "time": 7
+    },
+    {
+      "src": 4,
+      "dst": 2,
+      "time": 10
+    },
+    {
+      "src": 4,
+      "dst": 2,
+      "time": 11
     },
     {
       "src": 0,
-      "dst": 3
+      "dst": 4,
+      "time": 14
     },
     {
-      "src": 2,
-      "dst": 1
+      "src": 3,
+      "dst": 2,
+      "time": 18
+    },
+    {
+      "src": 1,
+      "dst": 2,
+      "time": 21
     },
     {
       "src": 0,
-      "dst": 1
+      "dst": 2,
+      "time": 23
     },
     {
-      "src": 2,
-      "dst": 3
-    },
-    {
-      "src": 2,
-      "dst": 4
-    },
-    {
-      "src": 2,
-      "dst": 1
+      "src": 3,
+      "dst": 2,
+      "time": 45
     }
   ]
 }

--- a/data_generator.py
+++ b/data_generator.py
@@ -41,7 +41,10 @@ def generate_dataset(
         dst = random.randint(0, num_ground - 1)
         while dst == src:
             dst = random.randint(0, num_ground - 1)
-        dataset["queries"].append({"src": src, "dst": dst})
+        time_slot = random.randint(0, num_slots - 1)
+        dataset["queries"].append({"src": src, "dst": dst, "time": time_slot})
+
+    dataset["queries"].sort(key=lambda q: q["time"])
 
     return dataset
 

--- a/train.py
+++ b/train.py
@@ -1,5 +1,6 @@
 import json
 import argparse
+import os
 from ISTN_ENV import ISTNEnv
 from MASys import MultiAgentSystem
 from LM import train_cmadr
@@ -10,11 +11,11 @@ def load_config(path: str) -> dict:
         return json.load(f)
 
 
-def build_env_from_data(data: dict) -> ISTNEnv:
+def build_env_from_data(data: dict, max_time: int | None = None) -> ISTNEnv:
     return ISTNEnv(
         num_satellites=len(data['sat_positions_per_slot'][0]),
         num_ground_stations=len(data['gs_positions']),
-        max_time=len(data['sat_positions_per_slot']),
+        max_time=max_time or len(data['sat_positions_per_slot']),
         sat_positions_per_slot=data['sat_positions_per_slot'],
         gs_positions=[tuple(p) for p in data['gs_positions']],
         queries=data['queries'],
@@ -23,10 +24,27 @@ def build_env_from_data(data: dict) -> ISTNEnv:
 
 def main(config_path: str):
     cfg = load_config(config_path)
-    with open(cfg['data_path'], 'r') as f:
-        data = json.load(f)
+    data_dir = cfg.get('data_dir', 'data')
+    data_name = cfg.get('data_name', 'dataset')
+    data_path = os.path.join(data_dir, f"{data_name}.json")
 
-    env = build_env_from_data(data)
+    train_cfg = cfg.get('train', {})
+    if not os.path.exists(data_path):
+        from data_generator import generate_dataset
+        data = generate_dataset(
+            train_cfg.get('num_satellites', 5),
+            train_cfg.get('num_ground_stations', 5),
+            train_cfg.get('num_queries', 10),
+            train_cfg.get('max_time', 50),
+        )
+        os.makedirs(data_dir, exist_ok=True)
+        with open(data_path, 'w') as f:
+            json.dump(data, f, indent=2)
+    else:
+        with open(data_path, 'r') as f:
+            data = json.load(f)
+
+    env = build_env_from_data(data, train_cfg.get('max_time'))
     mac = MultiAgentSystem(
         n_agents=env.num_satellites + env.num_ground_stations,
         n_nodes=env.num_satellites + env.num_ground_stations,
@@ -36,7 +54,7 @@ def main(config_path: str):
         device=cfg.get('device', 'cpu'),
     )
 
-    train_cfg = cfg.get('train', {})
+    model_dir = os.path.join(cfg.get('model_root', 'model'), f"{cfg.get('round',1)}_{data_name}")
     train_cmadr(
         env,
         mac,
@@ -46,8 +64,8 @@ def main(config_path: str):
         device=cfg.get('device', 'cpu'),
     )
 
-    mac.save(cfg['model_dir'])
-    print(f"Model saved to {cfg['model_dir']}")
+    mac.save(model_dir)
+    print(f"Model saved to {model_dir}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add time slot support for queries
- generate data with timed queries
- configure satellites, ground stations, queries and max time in config.json
- compute data/model paths from names
- update README

## Testing
- `python data_generator.py`
- `python train.py --config config.json`
- `python predict.py --config config.json`

------
https://chatgpt.com/codex/tasks/task_e_684db2b912288330a38a2c91c7675ecd